### PR TITLE
Update PostHog API host to custom Tiro Health endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,7 +970,7 @@
     <script>
       !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
       posthog.init('phc_Hay5R4mHZSxd6IfGDqlTCDVEEKTV4c6yaCtkymKdvbx', {
-          api_host: 'https://eu.i.posthog.com',
+          api_host: 'https://ua.tiro.health',
           defaults: '2026-01-30'
       })
     </script>


### PR DESCRIPTION
## Summary
Updated the PostHog analytics configuration to use a custom API endpoint instead of the default EU PostHog instance.

## Changes
- Changed PostHog `api_host` from `https://eu.i.posthog.com` to `https://ua.tiro.health`
- This routes all PostHog analytics events to the custom Tiro Health endpoint

## Details
This change redirects PostHog analytics traffic from the standard EU PostHog infrastructure to a custom domain (`ua.tiro.health`), likely for self-hosted or proxy analytics collection purposes.

https://claude.ai/code/session_017ui9WiC1wEG3HLP2DJ5ZWA