### PR TITLE
Add PostHog analytics tracking for calculator selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1785,6 +1785,10 @@
       function loadCalculator(id) {
         const calc = CALCULATORS.find(c => c.id === id);
         if (calc) form.setAttribute('questionnaire', calc.url);
+        window.posthog?.register?.({
+          calculator_id: id,
+          calculator_name: calc?.label || id,
+        });
         resultPanel.classList.remove('visible');
         resultItems.innerHTML = '';
         copyBtn.classList.remove('results__copy--attention', 'copied');


### PR DESCRIPTION
## Summary
Added PostHog analytics tracking to capture which calculator is selected by users, enabling better insights into calculator usage patterns.

## Key Changes
- Integrated PostHog event registration in the `loadCalculator()` function to track calculator selections
- Captures two data points:
  - `calculator_id`: The unique identifier of the selected calculator
  - `calculator_name`: The human-readable label of the calculator (falls back to ID if label unavailable)

## Implementation Details
The tracking is implemented defensively using optional chaining (`window.posthog?.register?.()`) to ensure the code gracefully handles scenarios where PostHog is not loaded or available, preventing any runtime errors.

https://claude.ai/code/session_014DW75ecdJJ77fCEmoHbisJ